### PR TITLE
Add test runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# julia:1.4.2-alpine is not available and 1.5.0 is not stable yet.
+FROM julia:1.4.2
+
+WORKDIR /opt/test-runner/
+
+COPY run.sh /opt/test-runner/bin/
+COPY run.jl /opt/test-runner/
+
+# Install Julia dependencies
+COPY Manifest.toml ./
+COPY Project.toml ./
+RUN julia --project -e 'using Pkg; Pkg.instantiate()'
+
+ENTRYPOINT ["sh", "/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY run.sh /opt/test-runner/bin/
 COPY run.jl /opt/test-runner/
 
 # Install Julia dependencies
+COPY src/ ./src/
 COPY Manifest.toml ./
 COPY Project.toml ./
 RUN julia --project -e 'using Pkg; Pkg.instantiate()'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Sascha Mann <git@mail.saschamann.eu> and contributors
+Copyright (c) 2020 Sascha Mann <git@mail.saschamann.eu>, Exercism and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Sascha Mann <git@mail.saschamann.eu> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -11,14 +11,6 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[ExercismTestReports]]
-deps = ["JSON", "Test"]
-git-tree-sha1 = "b11a775ebc06cccdedb4d5202bff6ebf252264eb"
-repo-rev = "master"
-repo-url = "https://github.com/exercism/ExercismTestReports.jl"
-uuid = "1eb284b9-8d61-4029-9486-1e2b9e72c2ed"
-version = "0.1.0-DEV"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -58,6 +50,11 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Suppressor]]
+git-tree-sha1 = "a819d77f31f83e5792a76081eee1ea6342ab8787"
+uuid = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+version = "0.2.0"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,67 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[ExercismTestReports]]
+deps = ["JSON", "Test"]
+git-tree-sha1 = "b11a775ebc06cccdedb4d5202bff6ebf252264eb"
+repo-rev = "master"
+repo-url = "https://github.com/exercism/ExercismTestReports.jl"
+uuid = "1eb284b9-8d61-4029-9486-1e2b9e72c2ed"
+version = "0.1.0-DEV"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "10134f2ee0b1978ae7752c41306e131a684e1f06"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.7"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,2 +1,20 @@
+name = "ExercismTestReports"
+uuid = "7236a586-7a51-4683-88ea-7abd70ff61e6"
+authors = ["Sascha Mann <git@mail.saschamann.eu>", "Exercism", "Contributors"]
+version = "0.1.0"
+
 [deps]
-ExercismTestReports = "1eb284b9-8d61-4029-9486-1e2b9e72c2ed"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Suppressor = "0.2"
+julia = "1.4"
+JSON = "0.21"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+ExercismTestReports = "1eb284b9-8d61-4029-9486-1e2b9e72c2ed"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,1 @@
 # Julia Test Runner
-
-## Julia-specific files
-
-| File | Purpose |
-|------|---------|
-| `Project.toml` | Specify `ExercismTestReports` as sole dependency. We're always going to use `ExercismTestReports#master`, so it is not necessary to specify compat bounds. |
-| `Manifest.toml` | Pin the dependency versions that the container is meant to use. Should be updated somewhat regularly. |
-| `run.jl` | Call the `ExercismTestReports` package to run the tests and create the `results.json` file. |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Julia Test Runner
+
+## Julia-specific files
+
+| File | Purpose |
+|------|---------|
+| `Project.toml` | Specify `ExercismTestReports` as sole dependency. We're always going to use `ExercismTestReports#master`, so it is not necessary to specify compat bounds. |
+| `Manifest.toml` | Pin the dependency versions that the container is meant to use. Should be updated somewhat regularly. |
+| `run.jl` | Call the `ExercismTestReports` package to run the tests and create the `results.json` file. |

--- a/run.jl
+++ b/run.jl
@@ -1,0 +1,9 @@
+using ExercismTestReports
+
+const SOLUTION_DIR = ARGS[2]
+const OUTPUT_DIR = ARGS[3]
+
+@debug "SOLUTION_DIR = " SOLUTION_DIR
+@debug "OUTPUT_DIR = " OUTPUT_DIR
+
+write(joinpath(OUTPUT_DIR, "results.json"), tojson(runtests(joinpath(SOLUTION_DIR, "runtests.jl"))...))

--- a/run.jl
+++ b/run.jl
@@ -6,4 +6,7 @@ const OUTPUT_DIR = ARGS[3]
 @debug "SOLUTION_DIR = " SOLUTION_DIR
 @debug "OUTPUT_DIR = " OUTPUT_DIR
 
-write(joinpath(OUTPUT_DIR, "results.json"), tojson(runtests(joinpath(SOLUTION_DIR, "runtests.jl"))...))
+let json_str = tojson(runtests(joinpath(SOLUTION_DIR, "runtests.jl"))...)
+    cleaned_json_str = replace(json_str, SOLUTION_DIR => "./")
+    write(joinpath(OUTPUT_DIR, "results.json"), cleaned_json_str)
+end

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+julia --project run.jl "$1" "$2" "$3"

--- a/src/ExercismTestReports.jl
+++ b/src/ExercismTestReports.jl
@@ -1,0 +1,10 @@
+module ExercismTestReports
+
+include("testset.jl")
+include("runner.jl")
+include("tojson.jl")
+
+export ReportingTestSet
+export runtests, tojson
+
+end

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -1,0 +1,18 @@
+using Suppressor
+using Test
+
+"""
+    runtests(testfile)
+
+Wrap the testfile in a ReportingTestSet and capture all output.
+Returns the output and ReportingTestSet.
+"""
+function runtests(testfile)
+    # The Suppressor macro wraps everything in a try...finally block, therefore rts needs to be introduced before
+    local rts
+    output = @capture_out rts = @testset ReportingTestSet "Wrapper Test" begin
+        include(testfile)
+    end
+
+    output, rts
+end

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -1,0 +1,46 @@
+# This file is derived from Julia's stdlib's DefaultTestSet implementation[1] released under the MIT licence [2].
+# A full copy of the licence is attached below.
+# [1] https://github.com/JuliaLang/julia/blob/v1.4.2/stdlib/Test/src/Test.jl#L742
+# [2] https://github.com/JuliaLang/julia/blob/v1.4.2/LICENSE.md
+# Copyright (c) 2009-2019: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and other contributors:
+#
+# https://github.com/JuliaLang/julia/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Test: AbstractTestSet, Broken, Pass, Fail, Error
+import Test: record, finish, scrub_backtrace, get_testset_depth, get_testset
+
+mutable struct ReportingTestSet <: AbstractTestSet
+    description::String
+    results::Vector
+end
+ReportingTestSet(desc) = ReportingTestSet(desc, [])
+
+# Store _all_ results
+record(ts::ReportingTestSet, t::Union{Fail, Error, Broken, Pass}) = (push!(ts.results, t); t)
+
+# When a ReportingTestSet finishes, it records itself to its parent
+# testset, if there is one. This allows for recursive printing of
+# the results at the end of the tests
+record(ts::ReportingTestSet, t::AbstractTestSet) = push!(ts.results, t)
+
+# Called at the end of a @testset, behaviour depends on whether
+# this is a child of another testset, or the "root" testset
+function finish(ts::ReportingTestSet)
+    # If we are a nested test set, do not print a full summary
+    # now - let the parent test set do the printing
+    if get_testset_depth() != 0
+        # Attach this test set to the parent test set
+        parent_ts = get_testset()
+        record(parent_ts, ts)
+        return ts
+    end
+
+    # return the testset so it is returned from the @testset macro
+    ts
+end

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -1,0 +1,55 @@
+using Test
+using JSON
+
+"""
+    tojson(output::String, ts::ReportingTestSet)
+
+Takes user output and a ReportingTestSet and converts it to a JSON string as expected by the interface.
+"""
+function tojson(output::String, ts::ReportingTestSet)
+    tests = Dict{String, Union{String, Nothing}}[]
+    for s in ts.results
+        status = "pass"
+        message = nothing
+        for t in s.results
+            if typeof(t) == Test.Fail
+                status = "fail"
+                message = string(t)
+            elseif typeof(t) == Test.Error
+                status = "error"
+                message = t.backtrace
+
+                # status "error" supersedes "fail", therefore the loop does not need to continue
+                break
+            end
+        end
+
+        # test object
+        push!(tests, Dict(
+            "name" => s.description,
+            "status" => status,
+            "message" => message,
+            "output" => first(output, 500), # only show the first 500 characters
+        ))
+    end
+
+    status = "pass"
+    message = nothing
+    for t in tests
+        if t["status"] == "fail"
+            status = t["status"]
+        elseif t["status"] == "error"
+            status = t["status"]
+            message = t["message"]
+
+            # status "error" supersedes "fail", therefore the loop does not need to continue
+            break
+        end
+    end
+    
+    JSON.json(Dict(
+        "status" => status,
+        "message" => message,
+        "tests" => tests,
+    ))
+end


### PR DESCRIPTION
I can't add @exercism/ops as reviewer for some reason.

A few things left to do, but I think merging this first makes it easier for you to review:

- Add support for nested testsets. This will be needed for v3 but for the research experiment/testing this will be sufficient.
- Add tests.
- Use PackageCompiler to compile a sysimage to reduce the compilation time of the `ExercismTestReports` module. This is optional and not trivial but could save costs in the long run.