### PR TITLE
Compile sysimage in first build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Automated tests
+    runs-on: ubuntu-latest
+
+    # Change this to add or remove tests
+    env:
+      TESTS: all_passing,all_passing_with_debugging,everything_at_once,one_fail,one_passing,truncated_output
+      JULIA_NUM_THREADS: 2
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build image
+      run: docker build -t jtr-img .
+    
+    - name: Run test runners
+      shell: julia --color=yes --project {0}
+      run: |
+        const tests = split(ENV["TESTS"], ",")
+        @info "The following tests will be run:\n  - $(join(tests, "\n  - "))"
+
+        mkdir("results")
+
+        Threads.@threads for test in tests
+          @info "Running test: $test..."
+
+          # Create container
+          run(`docker create --name jtr-$test jtr-img irrelevant /tmp/ /tmp/`)
+
+          # Copy test file to container
+          run(`docker cp "test/fixtures/$test/runtests.jl" jtr-$test:/tmp/`)
+
+          # Start container to run the test runner
+          run(`docker start -a jtr-$test`)
+
+          # Copy result back to host
+          run(`docker cp jtr-$test:/tmp/results.json "results/$test.json"`)
+        end
+    
+    - name: Install Julia dependencies for comparing results
+      run: julia --project --color=yes -e "using Pkg; Pkg.instantiate()"
+    
+    - name: Compare created and expected results.json
+      shell: julia --color=yes --project {0}
+      run: |
+        using JSON
+        using Test
+
+        const tests = split(ENV["TESTS"], ",")
+
+        @testset "Compare results.json files" begin
+          @testset "$test" for test in tests
+              expected = JSON.parsefile(joinpath("test", "fixtures", "$test", "results.json"))
+              created = JSON.parsefile(joinpath("results", "$test.json"))
+
+              @test expected == created
+          end
+        end

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,34 @@
 # julia:1.4.2-alpine is not available and 1.5.0 is not stable yet.
+FROM julia:1.4.2 AS build-sysimage
+
+WORKDIR /tmp/image-builder/
+
+# PackageCompiler needs gcc or clang
+RUN apt update && apt install -y clang
+
+# Copy ExercismTestReports
+COPY src/ ./src/
+COPY Manifest.toml ./
+COPY Project.toml ./
+# PackageSpec requires a git repo
+COPY .git/ ./.git/
+
+# Compile sysimage
+RUN julia --project=build-env -e 'using Pkg; Pkg.add("PackageCompiler"); Pkg.add(PackageSpec(path="."))'
+RUN julia --project=build-env -e 'using PackageCompiler; create_sysimage(:ExercismTestReports; sysimage_path = "test-runner-sysimage.so")'
+
 FROM julia:1.4.2
 
 WORKDIR /opt/test-runner/
 
-COPY run.sh /opt/test-runner/bin/
-COPY run.jl /opt/test-runner/
+COPY --from=build-sysimage /tmp/image-builder/test-runner-sysimage.so ./test-runner-sysimage.so
 
-# Install Julia dependencies
+# Copy ExercismTestReports
 COPY src/ ./src/
 COPY Manifest.toml ./
 COPY Project.toml ./
-RUN julia --project -e 'using Pkg; Pkg.instantiate()'
+
+COPY run.sh /opt/test-runner/bin/
+COPY run.jl /opt/test-runner/
 
 ENTRYPOINT ["sh", "/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ COPY Project.toml ./
 # PackageSpec requires a git repo
 COPY .git/ ./.git/
 
+# Prepare precompiliation files
+COPY precompile_execution_file.jl ./precompile_execution_file.jl
+COPY test/fixtures/everything_at_once/runtests.jl ./test/fixtures/everything_at_once/runtests.jl
+
 # Compile sysimage
 RUN julia --project=build-env -e 'using Pkg; Pkg.add("PackageCompiler"); Pkg.add(PackageSpec(path="."))'
-RUN julia --project=build-env -e 'using PackageCompiler; create_sysimage(:ExercismTestReports; sysimage_path = "test-runner-sysimage.so")'
+RUN julia --project=build-env -e 'using PackageCompiler; create_sysimage(:ExercismTestReports; sysimage_path = "test-runner-sysimage.so", precompile_execution_file="precompile_execution_file.jl")'
 
 FROM julia:1.4.2
 

--- a/precompile_execution_file.jl
+++ b/precompile_execution_file.jl
@@ -1,0 +1,9 @@
+# This file is required for PackageCompiler
+# See https://julialang.github.io/PackageCompiler.jl/dev/sysimages/#tracing-1 for more info
+
+using ExercismTestReports
+
+let json_str = tojson(runtests(joinpath("test", "fixtures", "everything_at_once", "runtests.jl"))...)
+    cleaned_json_str = replace(json_str, joinpath("test", "fixtures", "everything_at_once") => "./")
+    write(joinpath(mktempdir(), "results.json"), cleaned_json_str)
+end

--- a/run.jl
+++ b/run.jl
@@ -7,6 +7,12 @@ const OUTPUT_DIR = ARGS[3]
 @debug "OUTPUT_DIR = " OUTPUT_DIR
 
 let json_str = tojson(runtests(joinpath(SOLUTION_DIR, "runtests.jl"))...)
+    # Strip dir inside the test-runner container
     cleaned_json_str = replace(json_str, SOLUTION_DIR => "./")
+
+    # Strip Julia build env directories
+    # This may need to be changed if the build environment of Julia changes in future versions
+    cleaned_json_str = replace(cleaned_json_str, "/buildworker/worker/package_linux64/build/usr/share" => "[...]")
+
     write(joinpath(OUTPUT_DIR, "results.json"), cleaned_json_str)
 end

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-julia --project run.jl "$1" "$2" "$3"
+julia --project --sysimage test-runner-sysimage.so run.jl "$1" "$2" "$3"

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -29,7 +29,7 @@ function tojson(output::String, ts::ReportingTestSet)
             "name" => s.description,
             "status" => status,
             "message" => message,
-            "output" => first(output, 500), # only show the first 500 characters
+            "output" => isempty(output) ? nothing : first(output, 500), # only show the first 500 characters
         ))
     end
 

--- a/test/fixtures/all_passing/results.json
+++ b/test/fixtures/all_passing/results.json
@@ -1,0 +1,24 @@
+{
+    "status": "pass",
+    "message": null,
+    "tests": [
+        {
+            "name": "first test",
+            "status": "pass",
+            "message": null,
+            "output": ""
+        },
+        {
+            "name": "second test",
+            "status": "pass",
+            "message": null,
+            "output": ""
+        },
+        {
+            "name": "third test",
+            "status": "pass",
+            "message": null,
+            "output": ""
+        }
+    ]
+}

--- a/test/fixtures/all_passing/results.json
+++ b/test/fixtures/all_passing/results.json
@@ -6,19 +6,19 @@
             "name": "first test",
             "status": "pass",
             "message": null,
-            "output": ""
+            "output": null
         },
         {
             "name": "second test",
             "status": "pass",
             "message": null,
-            "output": ""
+            "output": null
         },
         {
             "name": "third test",
             "status": "pass",
             "message": null,
-            "output": ""
+            "output": null
         }
     ]
 }

--- a/test/fixtures/all_passing/runtests.jl
+++ b/test/fixtures/all_passing/runtests.jl
@@ -1,0 +1,14 @@
+using Test
+
+@testset "first test" begin
+    x = 1
+    @test x == 1
+end
+
+@testset "second test" begin
+    @test 2 == 2
+end
+
+@testset "third test" begin
+    @test 3 == 3
+end

--- a/test/fixtures/all_passing_with_debugging/results.json
+++ b/test/fixtures/all_passing_with_debugging/results.json
@@ -1,0 +1,18 @@
+{
+    "status": "pass",
+    "message": null,
+    "tests": [
+        {
+            "name": "first test",
+            "status": "pass",
+            "message": null,
+            "output": "x = 1\nI'M HERE!\n"
+        },
+        {
+            "name": "second test",
+            "status": "pass",
+            "message": null,
+            "output": "x = 1\nI'M HERE!\n"
+        }
+    ]
+}

--- a/test/fixtures/all_passing_with_debugging/runtests.jl
+++ b/test/fixtures/all_passing_with_debugging/runtests.jl
@@ -1,0 +1,12 @@
+using Test
+
+@testset "first test" begin
+    x = 1
+    @show x # Debugging
+    @test x == 1
+end
+
+@testset "second test" begin
+    println("I'M HERE!")
+    @test 2 == 2
+end

--- a/test/fixtures/everything_at_once/results.json
+++ b/test/fixtures/everything_at_once/results.json
@@ -1,6 +1,6 @@
 {
     "status": "error",
-    "message": "\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] top-level scope at ./runtests.jl:14\n [3] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113\n [4] top-level scope at ./runtests.jl:14\n",
+    "message": "\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] top-level scope at ./runtests.jl:14\n [3] top-level scope at [...]/julia/stdlib/v1.4/Test/src/Test.jl:1113\n [4] top-level scope at ./runtests.jl:14\n",
     "tests": [
         {
             "name": "first test",
@@ -17,7 +17,7 @@
         {
             "name": "third test",
             "status": "error",
-            "message": "\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] top-level scope at ./runtests.jl:14\n [3] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113\n [4] top-level scope at ./runtests.jl:14\n",
+            "message": "\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] top-level scope at ./runtests.jl:14\n [3] top-level scope at [...]/julia/stdlib/v1.4/Test/src/Test.jl:1113\n [4] top-level scope at ./runtests.jl:14\n",
             "output": "x = 1\n"
         }
     ]

--- a/test/fixtures/everything_at_once/results.json
+++ b/test/fixtures/everything_at_once/results.json
@@ -1,0 +1,24 @@
+{
+    "status": "error",
+    "message": "\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] top-level scope at ./runtests.jl:14\n [3] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113\n [4] top-level scope at ./runtests.jl:14\n",
+    "tests": [
+        {
+            "name": "first test",
+            "status": "pass",
+            "message": null,
+            "output": "x = 1\n"
+        },
+        {
+            "name": "second test",
+            "status": "fail",
+            "message": "Test Failed at ./runtests.jl:10\n  Expression: 1 == 2\n   Evaluated: 1 == 2",
+            "output": "x = 1\n"
+        },
+        {
+            "name": "third test",
+            "status": "error",
+            "message": "\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] top-level scope at ./runtests.jl:14\n [3] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113\n [4] top-level scope at ./runtests.jl:14\n",
+            "output": "x = 1\n"
+        }
+    ]
+}

--- a/test/fixtures/everything_at_once/runtests.jl
+++ b/test/fixtures/everything_at_once/runtests.jl
@@ -1,0 +1,15 @@
+using Test
+
+@testset "first test" begin
+    x = 1
+    @show x # Debugging
+    @test x == 1
+end
+
+@testset "second test" begin
+    @test 1 == 2
+end
+
+@testset "third test" begin
+    @test error("")
+end

--- a/test/fixtures/one_fail/results.json
+++ b/test/fixtures/one_fail/results.json
@@ -1,0 +1,24 @@
+{
+    "status": "fail",
+    "message": null,
+    "tests": [
+        {
+            "name": "first test",
+            "status": "pass",
+            "message": null,
+            "output": ""
+        },
+        {
+            "name": "second test",
+            "status": "fail",
+            "message": "Test Failed at ./runtests.jl:9\n  Expression: x == 1\n   Evaluated: 2 == 1",
+            "output": ""
+        },
+        {
+            "name": "third test",
+            "status": "pass",
+            "message": null,
+            "output": ""
+        }
+    ]
+}

--- a/test/fixtures/one_fail/results.json
+++ b/test/fixtures/one_fail/results.json
@@ -6,19 +6,19 @@
             "name": "first test",
             "status": "pass",
             "message": null,
-            "output": ""
+            "output": null
         },
         {
             "name": "second test",
             "status": "fail",
             "message": "Test Failed at ./runtests.jl:9\n  Expression: x == 1\n   Evaluated: 2 == 1",
-            "output": ""
+            "output": null
         },
         {
             "name": "third test",
             "status": "pass",
             "message": null,
-            "output": ""
+            "output": null
         }
     ]
 }

--- a/test/fixtures/one_fail/runtests.jl
+++ b/test/fixtures/one_fail/runtests.jl
@@ -1,0 +1,14 @@
+using Test
+
+@testset "first test" begin
+    @test 1 == 1
+end
+
+@testset "second test" begin
+    x = 2
+    @test x == 1
+end
+
+@testset "third test" begin
+    @test 3 == 3
+end

--- a/test/fixtures/one_passing/results.json
+++ b/test/fixtures/one_passing/results.json
@@ -1,0 +1,12 @@
+{
+    "status": "pass",
+    "message": null,
+    "tests": [
+        {
+            "name": "first test",
+            "status": "pass",
+            "message": null,
+            "output": ""
+        }
+    ]
+}

--- a/test/fixtures/one_passing/results.json
+++ b/test/fixtures/one_passing/results.json
@@ -6,7 +6,7 @@
             "name": "first test",
             "status": "pass",
             "message": null,
-            "output": ""
+            "output": null
         }
     ]
 }

--- a/test/fixtures/one_passing/runtests.jl
+++ b/test/fixtures/one_passing/runtests.jl
@@ -1,0 +1,5 @@
+using Test
+
+@testset "first test" begin
+    @test 1 == 1
+end

--- a/test/fixtures/truncated_output/results.json
+++ b/test/fixtures/truncated_output/results.json
@@ -1,0 +1,12 @@
+{
+    "status": "pass",
+    "message": null,
+    "tests": [
+        {
+            "name": "first test",
+            "status": "pass",
+            "message": null,
+            "output": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+    ]
+}

--- a/test/fixtures/truncated_output/runtests.jl
+++ b/test/fixtures/truncated_output/runtests.jl
@@ -1,0 +1,6 @@
+using Test
+
+@testset "first test" begin
+    println("x"^5000)
+    @test 1 == 1
+end


### PR DESCRIPTION
This significantly reduces the time it takes to run the test-runner. However, the build time of the image is massively increased. This seems like a reasonable trade-off to me for our use case.

---

**Depends on #3! #3 needs to be reviewed and merged first**

---

fixes #5 