### PR TITLE
Specify CPU target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY test/fixtures/everything_at_once/runtests.jl ./test/fixtures/everything_at_
 
 # Compile sysimage
 RUN julia --project=build-env -e 'using Pkg; Pkg.add("PackageCompiler"); Pkg.add(PackageSpec(path="."))'
-RUN julia --project=build-env -e 'using PackageCompiler; create_sysimage(:ExercismTestReports; sysimage_path = "test-runner-sysimage.so", precompile_execution_file="precompile_execution_file.jl")'
+RUN julia --project=build-env -e 'using PackageCompiler; create_sysimage(:ExercismTestReports; sysimage_path = "test-runner-sysimage.so", precompile_execution_file="precompile_execution_file.jl", cpu_target="x86-64")'
 
 FROM julia:1.5.2
 


### PR DESCRIPTION
We could target the specific CPU used by the test-runner host but that seems a bit too fragile in case that ever changes.