### PR TITLE
[CI] Only run CI on pushes to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches: 
+      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
This avoids duplicate builds in PRs from branches within this repo.