### PR TITLE
Add manual deploy button

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Push Docker images to DockerHub and ECR
 on:
   push:
     branches: [main, master]
+  workflow_dispatch:
 
 jobs:
   multiple-registries:


### PR DESCRIPTION
Sometimes it's useful to manually trigger a deploy, for example when the base docker image has changed.