### PR TITLE
Trigger tests and deploy to update the image

### DIFF
--- a/test/fixtures/everything_at_once/results.json
+++ b/test/fixtures/everything_at_once/results.json
@@ -1,6 +1,6 @@
 {
     "status": "error",
-    "message": "\nStacktrace:\n [1] error(s::String)\n   @ Base ./error.jl:33\n [2] macro expansion\n   @ ./runtests.jl:14 [inlined]\n [3] macro expansion\n   @ [...]/julia/stdlib/v1.6/Test/src/Test.jl:1147 [inlined]\n [4] top-level scope\n   @ ./runtests.jl:14",
+    "message": "\nStacktrace:\n [1] error(s::String)\n   @ Base ./error.jl:33\n [2] macro expansion\n   @ ./runtests.jl:14 [inlined]\n [3] macro expansion\n   @ [...]/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]\n [4] top-level scope\n   @ ./runtests.jl:14",
     "tests": [
         {
             "name": "first test",
@@ -17,7 +17,7 @@
         {
             "name": "third test",
             "status": "error",
-            "message": "\nStacktrace:\n [1] error(s::String)\n   @ Base ./error.jl:33\n [2] macro expansion\n   @ ./runtests.jl:14 [inlined]\n [3] macro expansion\n   @ [...]/julia/stdlib/v1.6/Test/src/Test.jl:1147 [inlined]\n [4] top-level scope\n   @ ./runtests.jl:14",
+            "message": "\nStacktrace:\n [1] error(s::String)\n   @ Base ./error.jl:33\n [2] macro expansion\n   @ ./runtests.jl:14 [inlined]\n [3] macro expansion\n   @ [...]/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]\n [4] top-level scope\n   @ ./runtests.jl:14",
             "output": "x = 1\n"
         }
     ]


### PR DESCRIPTION
The base docker image `julia:1.6.0` no longer refers to a pre-release version, but now points at Julia 1.6.0