### PR TITLE
Handle all types of `Test.Result`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [targets]
-test = ["Test"]
+test = ["Test", "InteractiveUtils"]

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -12,7 +12,7 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import Test: AbstractTestSet, Broken, Pass, Fail, Error
+import Test: AbstractTestSet, Broken, Pass, Fail, Error, LogTestFailure
 import Test: record, finish, scrub_backtrace, get_testset_depth, get_testset
 
 mutable struct ReportingTestSet <: AbstractTestSet
@@ -22,7 +22,8 @@ end
 ReportingTestSet(desc) = ReportingTestSet(desc, [])
 
 # Store _all_ results
-record(ts::ReportingTestSet, t::Union{Fail, Error, Broken, Pass}) = (push!(ts.results, t); t)
+record(ts::ReportingTestSet, t::Union{Fail, Error, Broken, Pass, LogTestFailure}) =
+    (push!(ts.results, t); t)
 
 # When a ReportingTestSet finishes, it records itself to its parent
 # testset, if there is one. This allows for recursive printing of

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -100,6 +100,10 @@ function tojson(output::String, ts::ReportingTestSet)
                 status = "fail"
                 message = string(result)
                 test_code = "@test " * result.orig_expr
+            elseif result isa Test.LogTestFailure
+                status = "fail"
+                message = string(result)
+                test_code = "@test_log " * string(result.orig_expr)
             elseif result isa Test.Error
                 status = "error"
                 message = result.backtrace

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -103,7 +103,7 @@ function tojson(output::String, ts::ReportingTestSet)
             elseif result isa Test.LogTestFailure
                 status = "fail"
                 message = string(result)
-                test_code = "@test_log " * string(result.orig_expr)
+                test_code = "@test_logs $(join(result.patterns, ' ')) $(result.orig_expr)"
             elseif result isa Test.Error
                 status = "error"
                 message = result.backtrace

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -109,7 +109,10 @@ function tojson(output::String, ts::ReportingTestSet)
                 message = result.backtrace
                 test_code = "@test " * result.orig_expr
             elseif result isa Test.Broken
-                status = "fail"
+                if result.test_type === :skipped
+                    continue
+                end
+                # TODO: In the future we might have a new `status = skip`
                 message = string(result)
                 test_code = result.test_type === :skipped ? "@test_skip " : "@test "
                 test_code *= string(result.orig_expr)

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -104,6 +104,11 @@ function tojson(output::String, ts::ReportingTestSet)
                 status = "error"
                 message = result.backtrace
                 test_code = "@test " * result.orig_expr
+            elseif result isa Test.Broken
+                status = "fail"
+                message = string(result)
+                test_code = result.test_type === :skipped ? "@test_skip " : "@test "
+                test_code *= string(result.orig_expr)
             elseif result isa Test.AbstractTestSet
                 # Descend into nested test sets
                 child_has_failed = walk!(tests, name, result)

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -114,7 +114,7 @@ function tojson(output::String, ts::ReportingTestSet)
                 end
                 # TODO: In the future we might have a new `status = skip`
                 message = string(result)
-                test_code = result.test_type === :skipped ? "@test_skip " : "@test "
+                test_code = result.test_type === :skipped ? "@test_skip " : "@test_broken "
                 test_code *= string(result.orig_expr)
             elseif result isa Test.AbstractTestSet
                 # Descend into nested test sets

--- a/test/fixtures/test_logs/results.json
+++ b/test/fixtures/test_logs/results.json
@@ -1,0 +1,12 @@
+{
+    "status": "fail",
+    "version": 2,
+    "tests": [
+        {
+            "name": "",
+            "test_code": "@test_log nothing",
+            "status": "fail",
+            "message": "Log Test Failed at ./runtests.jl:3\n  Expression: nothing\n  Log Pattern: (:info, \"Blabla\")\n  Captured Logs: \n"
+        }
+    ]
+}

--- a/test/fixtures/test_logs/results.json
+++ b/test/fixtures/test_logs/results.json
@@ -4,7 +4,7 @@
     "tests": [
         {
             "name": "",
-            "test_code": "@test_log nothing",
+            "test_code": "@test_logs (:info, \"Blabla\") nothing",
             "status": "fail",
             "message": "Log Test Failed at ./runtests.jl:3\n  Expression: nothing\n  Log Pattern: (:info, \"Blabla\")\n  Captured Logs: \n"
         }

--- a/test/fixtures/test_logs/runtests.jl
+++ b/test/fixtures/test_logs/runtests.jl
@@ -1,0 +1,3 @@
+using Test
+
+@test_logs (:info, "Blabla") nothing

--- a/test/fixtures/test_skip/results.json
+++ b/test/fixtures/test_skip/results.json
@@ -1,12 +1,5 @@
 {
-    "status": "fail",
+    "status": "pass",
     "version": 2,
-    "tests": [
-        {
-            "name": "An extra exercise",
-            "test_code": "@test_skip 5 == 1",
-            "status": "fail",
-            "message": "Test Broken\n  Skipped: 5 == 1"
-        }
-    ]
+    "tests": []
 }

--- a/test/fixtures/test_skip/results.json
+++ b/test/fixtures/test_skip/results.json
@@ -1,0 +1,12 @@
+{
+    "status": "fail",
+    "version": 2,
+    "tests": [
+        {
+            "name": "An extra exercise",
+            "test_code": "@test_skip 5 == 1",
+            "status": "fail",
+            "message": "Test Broken\n  Skipped: 5 == 1"
+        }
+    ]
+}

--- a/test/fixtures/test_skip/runtests.jl
+++ b/test/fixtures/test_skip/runtests.jl
@@ -1,0 +1,6 @@
+using Test
+
+@testset "An extra exercise" begin
+    @test_skip 5 == 1
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ExercismTestReports
 using Test
+import InteractiveUtils
 
 # When running tests on this project, the solution_dir path is likely to be
 # in our home directory, which Julia prints differently, so we copy all the
@@ -12,7 +13,7 @@ cp(FIXTURES, joinpath(TEMPDIR, "fixtures"))
 const TMP_FIXTURES = joinpath(TEMPDIR, "fixtures")
 
 @testset "All possible test result types are covered" begin
-    @test Set(subtypes(Test.Result)) == Set([
+    @test Set(InteractiveUtils.subtypes(Test.Result)) == Set([
         Test.Pass, Test.Error, Test.LogTestFailure, Test.Broken, Test.Fail
     ])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,12 @@ const TEMPDIR = mktempdir()
 cp(FIXTURES, joinpath(TEMPDIR, "fixtures"))
 const TMP_FIXTURES = joinpath(TEMPDIR, "fixtures")
 
+@testset "All possible test result types are covered" begin
+    @test Set(subtypes(Test.Result)) == Set([
+        Test.Pass, Test.Error, Test.LogTestFailure, Test.Broken, Test.Fail
+    ])
+end
+
 @testset for fixture in readdir(TMP_FIXTURES)
     results = test_runner("", "$TMP_FIXTURES/$fixture/")
     reference = "$FIXTURES/$fixture/results.json"


### PR DESCRIPTION
Before, the test runner stopped without a `results.json` in case of a
```julia
@test_skip ...
```
Fixes #43.
