### PR TITLE
Use more failsafe method Base.Filesystem.contractuser

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ end
     results = test_runner("", "$TMP_FIXTURES/$fixture/")
     if endswith(fixture, "syntax_error")
         # Substitute prefix with local file name in stack trace
-        HOME_PREFIX = joinpath("~", relpath(pkgdir(ExercismTestReports), homedir()))
+        HOME_PREFIX = Base.contractuser(pkgdir(ExercismTestReports))
         TEST_PREFIX = "~/projects/exercism/repos/julia-test-runner"
         results = replace(results, HOME_PREFIX => TEST_PREFIX)
     end


### PR DESCRIPTION
See [discussion](https://github.com/exercism/julia-test-runner/pull/48#discussion_r720240120) for more details.