### PR TITLE
apt -> apt-get to silence warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM julia:1.8.2 AS build-sysimage
 WORKDIR /tmp/image-builder/
 
 # PackageCompiler needs gcc or clang
-RUN apt update && apt install -y clang
+RUN apt-get update && apt-get install -y clang
 
 # Copy ExercismTestReports
 COPY src/ ./src/


### PR DESCRIPTION
Using `apt` without an open tty causes it to emit a warning about its unstable CLI API.