### PR TITLE
Arguments compatibility in Julia's testing.

### DIFF
--- a/src/testset.jl
+++ b/src/testset.jl
@@ -19,7 +19,7 @@ mutable struct ReportingTestSet <: AbstractTestSet
     description::String
     results::Vector
 end
-ReportingTestSet(desc) = ReportingTestSet(desc, [])
+ReportingTestSet(desc; args...) = ReportingTestSet(desc, [])
 
 # Store _all_ results
 record(ts::ReportingTestSet, t::Union{Fail, Error, Broken, Pass, LogTestFailure}) =


### PR DESCRIPTION
A simple workaround to make `ReportingTestSet` compatible with the unit testing arguments (available since Julia v1.6).