### PR TITLE
Jtr v3.2 [DRAFT]

### DIFF
--- a/src/ExercismTestReports.jl
+++ b/src/ExercismTestReports.jl
@@ -16,7 +16,7 @@ This version is used in the tests for the test_runner itself.
 """
 function test_runner(exercise_slug, solution_dir)
     captured_stdout, testsets, concept = runtests(joinpath(solution_dir, "runtests.jl"))
-    json_str = tojson(captured_stdout, testsets)
+    json_str = tojson(captured_stdout, testsets, concept)
 
     # Strip dir inside the test-runner container
     cleaned_json_str = replace(json_str, solution_dir => "./")

--- a/src/ExercismTestReports.jl
+++ b/src/ExercismTestReports.jl
@@ -15,7 +15,7 @@ Like the three-argument version but returns a String encoding the contents of re
 This version is used in the tests for the test_runner itself.
 """
 function test_runner(exercise_slug, solution_dir)
-    captured_stdout, testsets = runtests(joinpath(solution_dir, "runtests.jl"))
+    captured_stdout, testsets, concept = runtests(joinpath(solution_dir, "runtests.jl"))
     json_str = tojson(captured_stdout, testsets)
 
     # Strip dir inside the test-runner container

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -5,14 +5,16 @@ using Test
     runtests(testfile)
 
 Wrap the testfile in a ReportingTestSet and capture all output.
-Returns the output and ReportingTestSet.
+Returns the output, ReportingTestSet, and a Bool indicating type of exercise: true for concept, false for practice or unspecified.
 """
 function runtests(testfile)
-    # The Suppressor macro wraps everything in a try...finally block, therefore rts needs to be introduced before
+    # The Suppressor macro wraps everything in a try...finally block, therefore rts and concept need to be introduced before
     local rts
+    local concept
     output = @capture_out rts = @testset ReportingTestSet "" begin
         include(testfile)
+        concept = (@isdefined EXERCISM_CONCEPT_EXERCISE) ? EXERCISM_CONCEPT_EXERCISE : false
     end
 
-    output, rts
+    output, rts, concept
 end

--- a/src/tojson.jl
+++ b/src/tojson.jl
@@ -10,10 +10,10 @@ const MAX_REPORTED_FAILURES_PER_TESTSET = 5
 const MAX_REPORTED_PASSING_TEST_CODE_PER_COLLAPSE = 5
 
 """
-    tojson(output::String, ts::ReportingTestSet)
+    tojson(output::String, ts::ReportingTestSet, concept::Bool)
 
-Takes user output and a ReportingTestSet and converts it to a JSON string as
-expected by the interface.
+Takes user output, a ReportingTestSet and Bool indicating a concept or practice exercise, 
+and converts it to a JSON string as expected by the interface.
 
 Here's a brief summary of the schema we're following:
 
@@ -55,7 +55,7 @@ For more information, check the reference:
 https://github.com/exercism/docs/blob/main/building/tooling/test-runners/interface.md
 """
 # TODO: Capture output per-test
-function tojson(output::String, ts::ReportingTestSet)
+function tojson(output::String, ts::ReportingTestSet, concept::Bool)
     if length(ts.results) == 1 && ts.results[1] isa Test.Error
         # There has been a syntax error or similar and no tests have run.
         # Otherwise ts.results[1] will be a ReportingTestSet.
@@ -84,7 +84,7 @@ function tojson(output::String, ts::ReportingTestSet)
     # All stdout from the top level test set, used for all tests.
     output = truncate_output(output)
     
-    function test_code(result::Test.Result, task_id)
+    function test_code(result::Test.Result)
         if hasproperty(result, :test_type) && startswith(string(result.test_type), "test_throws")
             "@test_throws $(result.data) $(result.orig_expr)"
         elseif result isa Test.LogTestFailure
@@ -95,7 +95,7 @@ function tojson(output::String, ts::ReportingTestSet)
             macro_name = result.test_type === :skipped ? "@test_skip " : "@test_broken "
             "$macro_name $(result.orig_expr)"
         else
-            if !isnothing(task_id) && hasproperty(result, :backtrace)
+            if concept && hasproperty(result, :backtrace)
                 # For concept test failure, return full Test.Result output minus the source and stacktrace.
                 strip(replace(string(result), r" at .+\n" => "\n", r"\n  Stacktrace[\s\S]*" => "", count=2))
             else 
@@ -137,11 +137,11 @@ function tojson(output::String, ts::ReportingTestSet)
 
         any_failed = any_failed || status in ("fail", "error")
 
-        return push!(tests, Dict(filter( ((k, v),) -> !isnothing(v), (
+        return push!(tests, Dict(filter(kv -> !isnothing(kv.second), (
             "name" => name,
             "status" => status,
             "message" => message,
-            "test_code" => test_code(result, task_id),
+            "test_code" => test_code(result),
             "output" => output,
             "task_id" => task_id
         ))))
@@ -179,9 +179,9 @@ function tojson(output::String, ts::ReportingTestSet)
             collapsed_name = num_passing == num_results ? name : "$name » $num_passing tests"
             # If many tests pass then the reported test_code will be excessively large, so we truncate it.
             if num_passing > MAX_REPORTED_PASSING_TEST_CODE_PER_COLLAPSE
-                code = join(map(test->test_code(test, task_id), passing_tests[1:MAX_REPORTED_PASSING_TEST_CODE_PER_COLLAPSE]), '\n') * "\n..."
+                code = join(map(test_code, passing_tests[1:MAX_REPORTED_PASSING_TEST_CODE_PER_COLLAPSE]), '\n') * "\n..."
             else
-                code = join(map(test->test_code(test, task_id), passing_tests), '\n')
+                code = join(map(test_code, passing_tests), '\n')
             end
 
             push!(tests, Dict(filter(kv -> !isnothing(kv.second), (

--- a/test/fixtures/v3/runtests.jl
+++ b/test/fixtures/v3/runtests.jl
@@ -1,5 +1,7 @@
 using Test
 
+const EXERCISM_CONCEPT_EXERCISE = true
+
 #Adapted from /verbose_testing/runtests.jl
 
 f(x) = x


### PR DESCRIPTION
This implementation of the relevant test runner functions could be of use if both:
1. Practice exercises start to have itemized hints and/or instructions AND
2. Concept exercises continue to have limited feedback for failures

Instead of relying on the numbers in `@testset` names to differentiate between concept and practice exercises, this relies on a defined constant `const EXERCISM_CONCEPT_EXERCISE` to be defined as `true` for concept exercises and `false` for practice exercises in the top level scope of `runtests.jl`.

Everything else is functionally the same as the current setup implemented in PR #135.

**Note:** before any merge, the concept exercises in `/exercism/julia` would require the definition of 
```julia
const EXERCISM_CONCEPT_EXERCISE = true
```
in their respective top-level scope of `runtests.jl` (see `/test/fixtures/v3/runtests.jl`) in order to maintain their current level of verbosity for failures. However, the lack of this constant is non-breaking and would be optional for practice exercises, since the default when the constant is not defined is to assume `false` (i.e. practice exercise).